### PR TITLE
New type errors Type_UnboundRecordField and Warning_OptionalArgumentNotErased

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -76,8 +76,28 @@ let type_UnboundValue err errLines =
 let type_SignatureMismatch err errLines = raise Not_found
 let type_SignatureItemMissing err errLines = raise Not_found
 let type_UnboundModule err errLines = raise Not_found
-let type_UnboundRecordField err errLines = raise Not_found
 let type_UnboundConstructor err errLines = raise Not_found
+
+let type_UnboundRecordField err errLines =
+  let filename = get_match filenameR err in
+  let line = int_of_string (get_match lineR err) in
+  let chars1 = int_of_string (get_match chars1R err) in
+  let chars2 = int_of_string (get_match chars2R err) in
+
+  let recordFieldR = {|Error: Unbound record field (.+)|} in
+  let recordField = get_match recordFieldR err in
+  let suggestionR = {|Hint: Did you mean (.+)\?|} in
+  let suggestion = get_match_maybe suggestionR err in
+    Type_UnboundRecordField {
+      fileInfo = {
+        content = Batteries.List.of_enum (BatFile.lines_of filename);
+        name = filename;
+        line = line;
+        cols = (chars1, chars2);
+      };
+      recordField = recordField;
+      suggestion = suggestion
+    }
 
 let type_UnboundTypeConstructor err errLines =
   let filename = get_match filenameR err in

--- a/src/main.ml
+++ b/src/main.ml
@@ -256,8 +256,19 @@ let warning_PatternNotExhaustive err errLines =
   }
 
 let warning_PatternUnused err errLines = raise Not_found
-let warning_OptionalArgumentNotErased err errLines = raise Not_found
-
+let warning_OptionalArgumentNotErased err errLines =
+  let filename = get_match filenameR err in
+  let line = int_of_string (get_match lineR err) in
+  let chars1 = int_of_string (get_match chars1R err) in
+  let chars2 = int_of_string (get_match chars2R err) in
+    Warning_OptionalArgumentNotErased {
+      fileInfo = {
+        content = Batteries.List.of_enum (BatFile.lines_of filename);
+        name = filename;
+        line = line;
+        cols = (chars1, chars2);
+      };
+    }
 (* need: list of legal characters *)
 let file_IllegalCharacter err errLines =
   let filename = get_match filenameR err in

--- a/src/reporter.ml
+++ b/src/reporter.ml
@@ -85,14 +85,6 @@ let print msg = match msg with
     (match suggestion with
     | None -> ()
     | Some h -> print_endline ("Hint: did you mean `" ^ h ^ "`?"))
-  | Warning_PatternNotExhaustive {fileInfo; unmatched; warningCode} ->
-    print_endline @@ printFile fileInfo;
-    Printf.printf "Warning %d: this match doesn't cover all possible values of the variant.\n" warningCode;
-    (match unmatched with
-    | [oneVariant] -> print_endline @@ "The case `" ^ oneVariant ^ "` is not matched"
-    | many ->
-        print_endline "These cases are not matched:";
-        List.iter (fun x -> print_endline @@ "- `" ^ x ^ "`") many)
   | Type_UnboundValue {fileInfo; unboundValue; suggestion} ->
     print_endline @@ printFile fileInfo;
     (match suggestion with
@@ -103,4 +95,15 @@ let print msg = match msg with
     (match suggestion with
     | None -> print_endline ("Field `" ^ recordField ^ "` can't be found in any declared types.")
     | Some hint -> print_endline ("Field `" ^ recordField ^ "` can't be found in any declared types. Did you mean `" ^ hint ^ "`?\n"))
+  | Warning_PatternNotExhaustive {fileInfo; unmatched; warningCode} ->
+    print_endline @@ printFile fileInfo;
+    Printf.printf "Warning %d: this match doesn't cover all possible values of the variant.\n" warningCode;
+    (match unmatched with
+    | [oneVariant] -> print_endline @@ "The case `" ^ oneVariant ^ "` is not matched"
+    | many ->
+        print_endline "These cases are not matched:";
+        List.iter (fun x -> print_endline @@ "- `" ^ x ^ "`") many)
+  | Warning_OptionalArgumentNotErased {fileInfo} ->
+    print_endline @@ printFile fileInfo;
+    print_endline ("this optional argument cannot be erased.");
   | _ -> print_endline "huh"

--- a/src/reporter.ml
+++ b/src/reporter.ml
@@ -98,4 +98,9 @@ let print msg = match msg with
     (match suggestion with
     | None -> print_endline ("`" ^ unboundValue ^ "` can't be found. Could it be a typo?")
     | Some hint -> Printf.printf "`%s` can't be found. Did you mean `%s`?\n" unboundValue hint)
+  | Type_UnboundRecordField {fileInfo; recordField; suggestion} ->
+    print_endline @@ printFile fileInfo;
+    (match suggestion with
+    | None -> print_endline ("Field `" ^ recordField ^ "` can't be found in any declared types.")
+    | Some hint -> print_endline ("Field `" ^ recordField ^ "` can't be found in any declared types. Did you mean `" ^ hint ^ "`?\n"))
   | _ -> print_endline "huh"

--- a/src/types.mli
+++ b/src/types.mli
@@ -70,11 +70,13 @@ type unparsableButWithFileInfo = {
   fileInfo: fileInfo;
   error: string;
 }
-
 type unboundRecordField = {
   fileInfo: fileInfo;
   recordField: string;
   suggestion: string option;
+}
+type optionalArgumentNotErased = {
+  fileInfo: fileInfo;
 }
 
 type message =
@@ -102,7 +104,7 @@ type message =
   | Warning_UnusedVariable of unusedVariable
   | Warning_PatternNotExhaustive of patternNotExhaustive
   | Warning_PatternUnused of unusedVariable
-  | Warning_OptionalArgumentNotErased of unusedVariable
+  | Warning_OptionalArgumentNotErased of optionalArgumentNotErased
   | File_IllegalCharacter of illegalCharacter
   | UnparsableButWithFileInfo of unparsableButWithFileInfo
   | Unparsable of string

--- a/src/types.mli
+++ b/src/types.mli
@@ -21,7 +21,6 @@ type unboundValue = {
 type signatureMismatch = {constructor: string; expectedCount: int; observedCount: int}
 type signatureItemMissing = {constructor: string; expectedCount: int; observedCount: int}
 type unboundModule = {constructor: string; expectedCount: int; observedCount: int}
-type unboundRecordField = {constructor: string; expectedCount: int; observedCount: int}
 type unboundConstructor = {constructor: string; expectedCount: int; observedCount: int}
 
 type unboundTypeConstructor = {
@@ -70,6 +69,12 @@ type patternNotExhaustive = {
 type unparsableButWithFileInfo = {
   fileInfo: fileInfo;
   error: string;
+}
+
+type unboundRecordField = {
+  fileInfo: fileInfo;
+  recordField: string;
+  suggestion: string option;
 }
 
 type message =


### PR DESCRIPTION
I reordered the match cases in `print` in `reporter.ml` to have `Warning_***`s all together.