### PR TITLE
Add Type_UnboundModule error

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -75,7 +75,26 @@ let type_UnboundValue err errLines =
 
 let type_SignatureMismatch err errLines = raise Not_found
 let type_SignatureItemMissing err errLines = raise Not_found
-let type_UnboundModule err errLines = raise Not_found
+
+let type_UnboundModule err errLines =
+  let filename = get_match filenameR err in
+  let line = int_of_string (get_match lineR err) in
+  let chars1 = int_of_string (get_match chars1R err) in
+  let chars2 = int_of_string (get_match chars2R err) in
+  let unboundModuleR = {|Error: Unbound module ([\w\.]*)|} in
+  let unboundModule = get_match unboundModuleR err in
+  let suggestionR = {|Error: Unbound module [\w\.]*[\s\S]Hint: Did you mean (.+)\?|} in
+  let suggestion = get_match_maybe suggestionR err in
+  Type_UnboundModule {
+    fileInfo = {
+      content = Batteries.List.of_enum (BatFile.lines_of filename);
+      name = filename;
+      line = line;
+      cols = (chars1, chars2);
+    };
+    unboundModule = unboundModule;
+    suggestion = suggestion;
+  }
 
 (* need: if there's a hint, show which record type it is *)
 let type_UnboundRecordField err errLines =

--- a/src/reporter.ml
+++ b/src/reporter.ml
@@ -104,7 +104,7 @@ let print msg = match msg with
   | Type_UnboundModule {fileInfo; unboundModule} ->
     print_endline @@ printFile fileInfo;
     print_endline ("Module `" ^ unboundModule ^ "` not found in included libraries.");
-    let pckName = String.lowercase unboundModule in
+    let pckName = BatString.lowercase unboundModule in
     print_endline (
       "Hint: your build rules might be missing a link. If you're using: \n" ^
       " - Oasis: make sure you have `"^ pckName ^"` under `BuildDepends` in your _oasis file.\n" ^

--- a/src/reporter.ml
+++ b/src/reporter.ml
@@ -101,6 +101,15 @@ let print msg = match msg with
     (match suggestion with
     | None -> print_endline ("Field `" ^ recordField ^ "` can't be found in any record type.")
     | Some hint -> print_endline ("Field `" ^ recordField ^ "` can't be found in any record type. Did you mean `" ^ hint ^ "`?\n"))
+  | Type_UnboundModule {fileInfo; unboundModule} ->
+    print_endline @@ printFile fileInfo;
+    print_endline ("Module `" ^ unboundModule ^ "` not found in included libraries.");
+    let pckName = String.lowercase unboundModule in
+    print_endline (
+      "Hint: your build rules might be missing a link. If you're using: \n" ^
+      " - Oasis: make sure you have `"^ pckName ^"` under `BuildDepends` in your _oasis file.\n" ^
+      " - ocamlbuild: make sure you have `-pkgs "^ pckName ^"` in your build command.\n" ^
+      " - ocamlc | ocamlopt: make sure you have `-I +"^ pckName ^"` in your build command before the source files.")
   | Warning_PatternNotExhaustive {fileInfo; unmatched; warningCode} ->
     print_endline @@ printFile fileInfo;
     Printf.printf "Warning %d: this match doesn't cover all possible values of the variant.\n" warningCode;

--- a/src/types.mli
+++ b/src/types.mli
@@ -20,7 +20,13 @@ type unboundValue = {
 }
 type signatureMismatch = {constructor: string; expectedCount: int; observedCount: int}
 type signatureItemMissing = {constructor: string; expectedCount: int; observedCount: int}
-type unboundModule = {constructor: string; expectedCount: int; observedCount: int}
+
+type unboundModule = {
+  fileInfo: fileInfo;
+  unboundModule: string;
+  suggestion: string option;
+}
+
 type unboundConstructor = {constructor: string; expectedCount: int; observedCount: int}
 
 type unboundTypeConstructor = {

--- a/tests/type_UnboundModule/type_UnboundModule_1.ml
+++ b/tests/type_UnboundModule/type_UnboundModule_1.ml
@@ -1,0 +1,1 @@
+open Camlp4;;

--- a/tests/type_UnboundModule/type_UnboundModule_1_expected.txt
+++ b/tests/type_UnboundModule/type_UnboundModule_1_expected.txt
@@ -1,0 +1,9 @@
+[36mtests/type_UnboundModule/type_UnboundModule_1.ml:1 5-11
+[0m1 | open [31mCamlp4[0m;;
+         ^^^^^^
+
+Module `Camlp4` not found in included libraries.
+Hint: your build rules might be missing a link. If you're using: 
+ - Oasis: make sure you have `camlp4` under `BuildDepends` in your _oasis file.
+ - ocamlbuild: make sure you have `-pkgs camlp4` in your build command.
+ - ocamlc | ocamlopt: make sure you have `-I +camlp4` in your build command before the source files.


### PR DESCRIPTION
Hint containing ocamlc/ocamlbuild/oasis support. Not perfect yet, you
can still encounter errors related to this like:
"No implementations provided for the following modules" which require a
different solution. We're also not using the suggestion right now
because we can't trigger a Hint from the compiler (even a slight typo
with the linked library doesn't seem to do it).