### PR TITLE
Better type comparison

### DIFF
--- a/src/reporter.ml
+++ b/src/reporter.ml
@@ -18,6 +18,7 @@ let pad ?(ch=' ') content n =
   (BatString.make (n - (BatString.length content)) ch) ^ content
 
 let red = ANSITerminal.sprintf [ANSITerminal.red; ANSITerminal.Underlined] "%s"
+let green = ANSITerminal.sprintf [ANSITerminal.green] "%s"
 
 let highlight ?first ?last str =
   (BatString.slice ?last:first str)
@@ -75,7 +76,17 @@ let printAssumingErrorsAndWarnings l = l |> BatList.iter (fun {fileInfo; errors;
       Printf.printf "This needs to be applied to %d argument(s), we found %d.\n" expectedCount actualCount
     | Type_IncompatibleType {actual; expected} ->
       print_endline @@ printFile fileInfo range;
-      print_endline ("This is " ^ actual ^ ", wanted " ^ expected ^ " instead.")
+      print_endline @@
+        Table.table
+        ~align:Table.Left
+        ~style:{
+          Table.top = ("", "", "", "");
+          Table.middle = ("", "", "", "");
+          Table.bottom = ("", "", "", "");
+          Table.vertical = ("", "  ", "");
+        }
+        ~padding:0
+        [[(red "This is:"); actual]; [(green "Wanted:"); expected]]
     | Type_NotAFunction {actual} ->
       print_endline @@ printFile fileInfo range;
       print_endline ("This is " ^ actual ^ ". You seem to have called it as a function.");

--- a/src/table.ml
+++ b/src/table.ml
@@ -3,8 +3,12 @@ type align =
   | Right
   | Center
 
+let ansiR = {|\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]|}
+let getLength s = BatString.length (Pcre.replace ~pat:ansiR s)
+
 let pad ~align ~totalWidth content =
-  let freeSpace = totalWidth - (BatString.length content) in
+  let freeSpace = totalWidth - (getLength content) in
+
   match align with
   | Left -> content ^ (BatString.make freeSpace ' ')
   | Right -> (BatString.make freeSpace ' ') ^ content
@@ -21,8 +25,7 @@ let drawHorizontalLine ~style:(left, mid, right, horizontal) ~row ~maxes =
     |> BatList.interleave ~first:left ~last:(right ^ "\n") mid
     |> BatString.concat ""
 
-let column l i = BatList.map (fun row -> BatString.length @@ BatList.nth row i) l
-
+let column l i = BatList.map (fun row -> getLength @@ BatList.at row i) l
 (* -let onlyVertical =    ("┌", "┬", "┐", "├", "┼", "┤", "└", "┴", "┘", "", "│") *)
 (* -let onlyHorizontal =  (" ", "─", " ", " ", "─", " ", " ", "─", " ", "─", " ")
 -let compact =         ("", "", "", "", "", "", "", "", "", "", "")
@@ -118,7 +121,7 @@ let table ?(align=Left) ?(style=simple) ?(padding=1) lists =
     (drawHorizontalLine ~style:(mLeft, mMid, mRight, mBar) ~row: anyRow ~maxes)
   |> BatString.concat ""
 
-let () = print_endline @@ table [["1"; "213ad"; "3";]; ["4"; "5"; "6"]]
+(* let () = print_endline @@ table [["1"; "213ad"; "3";]; ["4"; "5"; "6"]]
 let () = print_endline @@ table ~style:double ~align:Right [["1"; "213ad"; "3";]; ["4"; "5"; "6"]]
 let () = print_endline @@ table ~style:dotted ~align:Center [["1"; "213ad"; "3";]; ["4"; "5"; "6"]]
 let () = print_endline @@ table ~style:compact [["1"; "213ad"; "3";]; ["4"; "5"; "6"]]
@@ -127,4 +130,4 @@ let () = print_endline @@ table ~style:onlyVertical [["1"; "213ad"; "3";]; ["4";
 let () = print_endline @@ table ~style:onlyHorizontal ~align:Right [["1"; "213ad"; "3";]; ["4"; "5"; "6"]]
 let () = print_endline @@ table ~style:onlyInner [["1"; "type bread ="]; ["2"; "  | Coconut of string"]; ["3"; "let morning = Coconut"]]
 let () = print_endline @@ table ~style:onlyOuter [["1"; "type bread ="]; ["2"; "  | Coconut of string"]; ["3"; "let morning = Coconut"]]
-let () = print_endline @@ table ~style:testCode [["1"; "type bread ="]; ["2"; "  | Coconut of string"]; ["3"; "let morning = Coconut"]]
+let () = print_endline @@ table ~style:testCode [["1"; "type bread ="]; ["2"; "  | Coconut of string"]; ["3"; "let morning = Coconut"]] *)


### PR DESCRIPTION
Made error for `Type_IncompatibleType` align nicely.

Also modified the `table` function to accept a `lengths` argument. Check commit message for details.