### PR TITLE
Normalized capitalization of test files

### DIFF
--- a/tests/test.ml
+++ b/tests/test.ml
@@ -19,7 +19,7 @@ let folders = [
   ("type_UnboundTypeConstructor", 2);
   ("type_UnboundValue", 4);
   ("warning_OptionalArgumentNotErased", 2);
-  ("Warning_PatternNotExhaustive", 2);
+  ("warning_PatternNotExhaustive", 2);
   ("warning_PatternUnused", 1);
 ]
 

--- a/tests/warning_PatternNotExhaustive/warning_PatternNotExhaustive_1_expected.txt
+++ b/tests/warning_PatternNotExhaustive/warning_PatternNotExhaustive_1_expected.txt
@@ -1,4 +1,4 @@
-[36mtests/Warning_PatternNotExhaustive/Warning_PatternNotExhaustive_1.ml:5:12-6:13
+[36mtests/warning_PatternNotExhaustive/warning_PatternNotExhaustive_1.ml:5:12-6:13
 [0m2 |   | Hello
 3 |   | Goodbye
 4 | 

--- a/tests/warning_PatternNotExhaustive/warning_PatternNotExhaustive_2_expected.txt
+++ b/tests/warning_PatternNotExhaustive/warning_PatternNotExhaustive_2_expected.txt
@@ -1,4 +1,4 @@
-[36mtests/Warning_PatternNotExhaustive/Warning_PatternNotExhaustive_2.ml:8:12-9:13
+[36mtests/warning_PatternNotExhaustive/warning_PatternNotExhaustive_2.ml:8:12-9:13
 [0m5 |   | Nihao of int
 6 |   | LongAssGreetingInSomeSuperObscureLanguageIWannaHaveALineBreakHere
 7 | 


### PR DESCRIPTION
PatternNotExhaustive test was causing a _No such file or directory_ error because Warning_PatternNotExhaustive_1_expected.txt and Warning_PatternNotExhaustive_2_expected.txt did not match expected capitalization. This should resolve it.